### PR TITLE
upgrade to Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 name               in ThisBuild := "csvside"
 organization       in ThisBuild := "io.underscore"
-version            in ThisBuild := "0.16.0-SNAPSHOT"
-scalaVersion       in ThisBuild := "2.11.8"
-crossScalaVersions in ThisBuild := Seq("2.11.8")
+version            in ThisBuild := "1.0.0-SNAPSHOT"
+scalaVersion       in ThisBuild := "2.12.4"
+crossScalaVersions in ThisBuild := Seq("2.12.4", "2.11.8")
 
 licenses += ("Apache-2.0", url("http://apache.org/licenses/LICENSE-2.0"))
 
@@ -14,12 +14,13 @@ scalacOptions ++= Seq(
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
 
+
 libraryDependencies ++= Seq(
-  "com.bizo"        %% "mighty-csv" % "0.2",
+  "net.sf.opencsv"   % "opencsv"    % "2.3",
   "org.typelevel"   %% "cats-core"  % "0.9.0",
   "com.chuusai"     %% "shapeless"  % "2.3.2",
-  "com.davegurnell" %% "unindent"   % "1.0.0" % Test,
-  "org.scalatest"   %% "scalatest"  % "2.2.4" % Test
+  "com.davegurnell" %% "unindent"   % "1.1.0" % Test,
+  "org.scalatest"   %% "scalatest"  % "3.0.5" % Test
 )
 
 pomExtra in Global := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/src/main/scala/csvside/Mighty.scala
+++ b/src/main/scala/csvside/Mighty.scala
@@ -1,0 +1,90 @@
+package csvside
+
+import au.com.bytecode.opencsv.{ CSVReader => OpenCSVReader }
+import au.com.bytecode.opencsv.{ CSVWriter => OpenCSVWriter }
+import java.io.{ FileReader, InputStreamReader, FileInputStream }
+
+/*
+ * This code from Apache 2.0 Licensed mighty-csv
+ *
+ * https://github.com/t-pleasure/mighty-csv/ at version 2dcee78
+*/
+object Mighty {
+
+  type Row = Array[String]
+
+  class CSVReader(reader: OpenCSVReader) extends Iterator[Row] {
+    private[this] val rows: Iterator[Row] = new CSVRowIterator(reader).flatten
+
+    override def hasNext(): Boolean = rows.hasNext
+    override def next(): Row = rows.next()
+
+    def apply[T](fn: Row => T): Iterator[T] = {
+      this.map { fn }
+    }
+
+    def close() {
+      reader.close()
+    }
+  }
+
+
+  /**
+   * Wrapper class for OpenCSVReader to allow for Thread-safe CSV row iteration.
+   * Note: This class is actually an iterator over Option[Row]. This is to
+   * allow for safer/easy handling of cases where the the rows are null.
+   */
+  class CSVRowIterator(reader: OpenCSVReader) extends Iterator[Option[Row]] {
+    var nextLine: Option[Row] = Option(reader.readNext())
+
+    override def hasNext() = nextLine.isDefined
+
+    override def next(): Option[Row] = {
+      val cur: Option[Row] = nextLine
+      nextLine = Option(reader.readNext())
+      cur
+    }
+
+    /** converts to Iterator[Row] */
+    def asRows(): Iterator[Row] = {
+      this.flatten
+    }
+
+    /** alias for mapping */
+    def apply[T](fn: Row => T): Iterator[T] = {
+      this.flatten.map { fn }
+    }
+
+    /** closes reader */
+    def close() {
+      reader.close()
+    }
+  }
+
+  /** 
+   * Allows for writing rows with Map[String,String] objects.
+   * headers -- specifies the list of values to extract from Map[String,String] objects.
+   *            Also specifies the column ordering of the output.
+   */
+  class CSVDictWriter(writer: OpenCSVWriter, headers: Seq[String]) {
+    
+    /** writes the header */
+    def writeHeader() { writer.writeNext(headers.toArray) }
+    
+    /** writes a row */
+    def write(row: Map[String, String]) { 
+      val rowData: Array[String] = headers.map { col: String =>
+        row.get(col) getOrElse sys.error("Column (%s) not found in row [%s]".format(col, row.toString))
+      }.toArray
+      
+      writer.writeNext(rowData)
+    }
+
+    def close() { writer.close() }
+
+    def flush() { writer.synchronized { writer.flush() } }
+  }
+
+}
+
+

--- a/src/main/scala/csvside/Read.scala
+++ b/src/main/scala/csvside/Read.scala
@@ -1,7 +1,6 @@
 package csvside
 
-import com.bizo.mighty.csv.{CSVReader => MightyCsvReader}
-import au.com.bytecode.opencsv.{CSVReader => OpenCsvReader}
+import au.com.bytecode.opencsv.{CSVReader => OpenCSVReader}
 import java.io.{File, Reader, FileReader, StringReader}
 import scala.collection.JavaConversions._
 import cats.data.Validated.{valid, invalid}
@@ -57,5 +56,6 @@ trait ReadInternals {
     readerIterator(new StringReader(in))
 
   def readerIterator(reader: Reader): Iterator[List[String]] =
-    MightyCsvReader(new OpenCsvReader(reader)).map(_.toList)
+    new Mighty.CSVReader(new OpenCSVReader(reader)).map(_.toList)
+
 }

--- a/src/main/scala/csvside/Write.scala
+++ b/src/main/scala/csvside/Write.scala
@@ -1,7 +1,6 @@
 package csvside
 
-import au.com.bytecode.opencsv.{CSVWriter => OpenCsvWriter}
-import com.bizo.mighty.csv.{CSVDictWriter => MightyCsvWriter}
+import au.com.bytecode.opencsv.{CSVWriter => OpenCSVWriter}
 import java.io.{File, Writer, FileWriter, StringWriter}
 import cats.data.Validated.{valid, invalid}
 
@@ -22,7 +21,7 @@ trait Write {
   def toWriter[A](items: Seq[A], out: Writer)(implicit rowWriter: RowWriter[A]): Unit = {
     val heads  = rowWriter.heads
     val rows   = items.zipWithIndex map rowWriter.tupledWrite
-    val mighty = MightyCsvWriter(new OpenCsvWriter(out), heads map (_.text))
+    val mighty = new Mighty.CSVDictWriter(new OpenCSVWriter(out), heads map (_.text))
     mighty.writeHeader
     rows.foreach { row =>
       mighty.write(row.values.map { case (head, value) => (head.text) -> value })


### PR DESCRIPTION
There's no 2.12 build of mighty-csv (PR issued, though), so I've pulled what we need into `Mighty.scala` and we now depend directly on open CSV.

I've taken the grand step of bumping this to version 1.